### PR TITLE
Upgrade dependency Pillow to 8.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click==6.7
-Pillow==8.0.0
+Pillow==8.3.2
 requests==2.20.0
 robobro==0.5.3


### PR DESCRIPTION
 - Currently, tippy top doesn't work with Python version 3.10.x
 - As per https://pillow.readthedocs.io/en/stable/installation.html#python-support, it will now work for Python 3.10.x as well