### PR TITLE
Fix image loading from http response

### DIFF
--- a/make_manifest.py
+++ b/make_manifest.py
@@ -125,9 +125,10 @@ def get_best_icon(minwidth, images):
                     # If it is. We want it. We are done here.
                     return url
 
-                with Image.open(StringIO(response.content)) as img:
+                with Image.open(BytesIO(response.content)) as img:
                     width, _ = img.size
-            except:
+            except Exception as e:
+                logging.info(f'Exception: "{str(e)}" fetching (or opening) icon {url}')
                 pass
         if width and width > image_width:
             image_url = url


### PR DESCRIPTION
Fixes https://github.com/mozilla/tippy-top-sites/issues/29

Tested via following command:

`python make_manifest.py --count 1 --topsitesfile ../top\ 1\ domains.csv  --minwidth 16 --saverawsitedata rawdata.txt > icons.json`

After this fix, the `icons.json` have `google.com` as one of the entries as follows:
```
    {
        "image_url": "https://www.google.com/favicon.ico",
        "domains": [
            "google.com"
        ]
    }
```

where `../top\ 1\ domains.csv` file contains just one line with `1, google.com` as its content