### PR TITLE
Improved icon selector for icon url parsing

### DIFF
--- a/make_manifest.py
+++ b/make_manifest.py
@@ -14,7 +14,7 @@ from robobrowser import RoboBrowser
 from nsfw import is_nsfw
 
 
-LINK_SELECTOR = 'link[rel=apple-touch-icon], link[rel=apple-touch-icon-precomposed], link[rel="icon shortcut"], link[rel="shortcut icon"], link[rel="icon"]'
+LINK_SELECTOR = 'link[rel=apple-touch-icon], link[rel=apple-touch-icon-precomposed], link[rel="icon shortcut"], link[rel="shortcut icon"], link[rel="icon"], link[rel="SHORTCUT ICON"]'
 META_SELECTOR = 'meta[name=apple-touch-icon]'
 FIREFOX_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:58.0) Gecko/20100101 Firefox/58.0'
 IPHONE_UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) Version/10.0 Mobile/14D27 Safari/602.1'


### PR DESCRIPTION
Fixes https://github.com/mozilla/tippy-top-sites/issues/25

Tested via following command:

`python make_manifest.py --count 2 --topsitesfile ../top\ 2\ domains.csv  --minwidth 16 --saverawsitedata rawdata.txt > icons.json`

where `../top\ 2\ domains.csv` file contains 2 lines with `microsoft.com` and `office365.com` domains.

After this fix, the `icons.json` does contain both of these domains.