### PR TITLE
Handle domains that explicitly require "www." in the begining

### DIFF
--- a/make_manifest.py
+++ b/make_manifest.py
@@ -149,10 +149,14 @@ def collect_icons_for_top_sites(minwidth, topsitesfile, count, extra_domains=Non
 
         url = 'https://{hostname}'.format(hostname=hostname)
         icons = fetch_icons(url)
-        if len(icons) == 0:
-            # Retry with http
-            url = 'http://{hostname}'.format(hostname=hostname)
+        if len(icons) == 0 and 'www.' not in hostname:
+            # Retry with www. in the hostname as some domains require it explicitly.
+            url = 'https://www.{hostname}'.format(hostname=hostname)
             icons = fetch_icons(url)
+            if len(icons) == 0:
+                # Retry with http
+                url = 'http://{hostname}'.format(hostname=hostname)
+                icons = fetch_icons(url)
         best_icon_url = get_best_icon(minwidth, icons)
         results.append({
             'hostname': hostname,

--- a/make_manifest.py
+++ b/make_manifest.py
@@ -153,10 +153,7 @@ def collect_icons_for_top_sites(minwidth, topsitesfile, count, extra_domains=Non
             # Retry with www. in the hostname as some domains require it explicitly.
             url = f"https://www.{hostname}"
             icons = fetch_icons(url)
-            if len(icons) == 0:
-                # Retry with http
-                url = f"http://{hostname}"
-                icons = fetch_icons(url)
+
         best_icon_url = get_best_icon(minwidth, icons)
         results.append({
             'hostname': hostname,

--- a/make_manifest.py
+++ b/make_manifest.py
@@ -151,11 +151,11 @@ def collect_icons_for_top_sites(minwidth, topsitesfile, count, extra_domains=Non
         icons = fetch_icons(url)
         if len(icons) == 0 and 'www.' not in hostname:
             # Retry with www. in the hostname as some domains require it explicitly.
-            url = 'https://www.{hostname}'.format(hostname=hostname)
+            url = f"https://www.{hostname}"
             icons = fetch_icons(url)
             if len(icons) == 0:
                 # Retry with http
-                url = 'http://{hostname}'.format(hostname=hostname)
+                url = f"http://{hostname}"
                 icons = fetch_icons(url)
         best_icon_url = get_best_icon(minwidth, icons)
         results.append({


### PR DESCRIPTION
Fixes https://github.com/mozilla/tippy-top-sites/issues/27

Tested via following command:

`python make_manifest.py --count 1 --topsitesfile ../top\ 1\ domains.csv  --minwidth 16 --saverawsitedata rawdata.txt > icons.json`

where `../top\ 1\ domains.csv` file contains just one line with `163.com` domain

After this fix, the `icons.json` have `163.com` as one of the entries.